### PR TITLE
Fix "PHP Notice: Undefined variable: GLOBALS"

### DIFF
--- a/OLE/ChainedBlockStream.php
+++ b/OLE/ChainedBlockStream.php
@@ -144,7 +144,9 @@ class OLE_ChainedBlockStream extends PEAR
     function stream_close()
     {
         $this->ole = null;
-        unset($GLOBALS['_OLE_INSTANCES']);
+        if (isset($GLOBALS)) {
+            unset($GLOBALS['_OLE_INSTANCES']);
+        }
     }
 
     /**


### PR DESCRIPTION
I'm getting this notice, so it looks like the presumption the variable exists is wrong...

I could resend this PR into official stream too, but it looks dead. And I'm using your hfig/MAPI, so I'd like to have it fixed...